### PR TITLE
Accumulate request will now not hang for GET requests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-- '5.1'
+- '6.3.1'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+- '5.1'
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 #Plugins
 
+Build Status [![Build Status](https://travis-ci.org/apigee/microgateway-plugins.svg?branch=accumulate-request-fixes)](https://travis-ci.org/apigee/microgateway-plugins)
+
 ##Overview
 This repo contains plugins for the [microgateway-core project](https://github.com/apigee/microgateway-core).  
 

--- a/accumulate-request/index.js
+++ b/accumulate-request/index.js
@@ -14,7 +14,6 @@
  * should only be used when it is known that request/response bodies are small.
  */
 module.exports.init = function(config, logger, stats) {
-
   function accumulate(req, data) {
     if (!req._chunks) req._chunks = [];
     req._chunks.push(data);
@@ -29,11 +28,13 @@ module.exports.init = function(config, logger, stats) {
 
     onend_request: function(req, res, data, next) {
       if (data && data.length > 0) accumulate(req, data);
-      var content = Buffer.concat(req._chunks);
+      var content = null;
+      if (req._chunks && req._chunks.length) {
+        content = Buffer.concat(req._chunks);
+      }
       delete req._chunks;
       next(null, content);
     }
-
   };
 
 }

--- a/test/accumulate-request-test.js
+++ b/test/accumulate-request-test.js
@@ -91,4 +91,17 @@ describe('accumulate request plugin', () => {
 
     plugin.ondata_request.apply(null, [req, {}, Buffer.alloc(5, 'a'), cb]);
   });
+
+  it('will call the callback with null if no data events are provided.', (done) => {
+    var onend_cb = (err, result) => {
+      assert.equal(err, null);
+      assert.equal(result, null); 
+      done();
+    } 
+
+    var req = {};
+
+    plugin.onend_request.apply(null, [req, {}, null, onend_cb]);  
+
+  });
 })

--- a/test/quota-test.js
+++ b/test/quota-test.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 var exampleConfig = { 
   EdgeMicroTestProduct: {
     allow: process.env.QUOTA_ALLOW,
-    interval: process.env.QUOTA_INTERVAL,
+    interval: Number(process.env.QUOTA_INTERVAL),
     timeUnit: process.env.QUOTA_TIMEUNIT,
     bufferSize: process.env.QUOTA_BUFFERSIZE,
     uri: process.env.QUOTA_URI,


### PR DESCRIPTION
The `accumulate-request` plugin would hang if a user issued a GET request against edgemicro and it was in sequence. 

This is because:
- There would be no `req._chunks` array created, and an error would be thrown. There is a concat call on this array of buffers that will not work for GET requests.

This solves that issue, and creates a test for this particular case.