### PR TITLE
fixing an issue with accumulate-response where a lack of response body will cause errors instead of a successful request response cycle.

### DIFF
--- a/accumulate-response/index.js
+++ b/accumulate-response/index.js
@@ -29,7 +29,10 @@ module.exports.init = function(config, logger, stats) {
 
     onend_response: function(req, res, data, next) {
       if (data && data.length > 0) accumulate(res, data);
-      var content = Buffer.concat(res._chunks);
+      var content = null;
+      if(res._chunks && res._chunks.length) {
+        content = Buffer.concat(res._chunks);
+      }
       delete res._chunks;
       next(null, content);
     }

--- a/test/accumulate-response-test.js
+++ b/test/accumulate-response-test.js
@@ -79,7 +79,7 @@ describe('accumulate response plugin', () => {
     plugin.onend_response.apply(null, [{}, res, Buffer.alloc(5, 'a'), onend_cb]);  
   });
 
-  it('will create a req._chunks object on the request object', (done) => {
+  it('will create a res._chunks object on the request object', (done) => {
     var res = {};
     var cb = (err, result) => {
       assert.equal(err, null);
@@ -91,4 +91,17 @@ describe('accumulate response plugin', () => {
 
     plugin.ondata_response.apply(null, [{}, res, Buffer.alloc(5, 'a'), cb]);
   });
+
+  it('will callback with null if no response body is present in targetResponse', (done) => {
+    var res = {};
+    var cb = (err, result) => {
+      assert.equal(err, null);
+      assert.equal(result, null);
+      done();
+    }
+
+    plugin.onend_response.apply(null, [{}, res, null, cb]);
+
+  });
+
 })


### PR DESCRIPTION
Fixes an issue similar to #12 the difference being if an empty response is coming back from the target edgemicro won't send an error message if this plugin is in the sequence.