### PR TITLE
Update to the quota plugin to not log errors if looking at the key or secret within the config object.

### DIFF
--- a/quota/index.js
+++ b/quota/index.js
@@ -13,8 +13,12 @@ module.exports.init = function(config, logger, stats) {
            return req.token.application_name; 
     }
   };
-
+  
   Object.keys(config).forEach(function(productName) {
+    //The config object also contains the key and secret.
+    if(productName == 'key' || productName == 'secret') {
+      return; 
+    }
     var product = config[productName];
     if (!product.uri && !product.key && !product.secret && !product.allow && !product.interval) {
       // skip non-quota config


### PR DESCRIPTION
Currently we iterate over products to setup the configuration for the quota plugin. That product configuration also includes the key and secret. Key and secret don't have values for configuring quota so we inadvertently alert a user to not configuring quota. This fixes that.

Nota bene:  Not married to this fix, but it can serve as a stop gap.