### PR TITLE
Updating to export newly added plugins.

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,5 +9,7 @@ module.exports = {
   quota:require('./quota'),
   'quota-memory':require('./quota-memory'),
   spikearrest:require('./spikearrest'),
-  'transform-uppercase':require('./transform-uppercase')
+  'transform-uppercase':require('./transform-uppercase'),
+  json2xml: require('./json2xml'),
+  healthcheck: require('./healthcheck')
 }


### PR DESCRIPTION
Plugins must be exported in the index.js. This corrects a bug where two new plugins were not exported.