### PR TITLE
Allow for configuration of a mask to didact certain pieces of data from an analytics record.

### DIFF
--- a/analytics/index.js
+++ b/analytics/index.js
@@ -9,6 +9,18 @@ module.exports.init = function(config, logger, stats) {
       record.apiproxy = res.proxy.name;
       record.apiproxy_revision = res.proxy.revision;
     }
+
+    if(config.mask) {
+      var maskString = config.mask.mask_string;
+      var fieldsToMask = config.mask.fields_to_mask;
+      fieldsToMask.forEach((f)=> {
+        //Only attempt to mask if the property exists.
+        if(record[f]) {
+          record[f] = maskString;
+        }
+      });
+    }
+    
     cb(null, record);
   };
 


### PR DESCRIPTION
A user may want to mask data out of an analytics record for security or privacy purposes.

This additional configuration will allow the simple substitution of a string for some parameters.


Example config:

```yaml
mask:
  mask_string: '*******'
  fields_to_mask:
    - request_url
    - request_path
    - access_token
```