### PR TITLE
Minor oauth fix. A trailing slash will not be required on proxy basepaths to have key verification work properly.

### DIFF
--- a/oauth/index.js
+++ b/oauth/index.js
@@ -203,6 +203,8 @@ module.exports.init = function (config, logger, stats) {
 // then check if that proxy is one of the authorized proxies in bootstrap
 const checkIfAuthorized = module.exports.checkIfAuthorized = function checkIfAuthorized(config, urlPath, proxy, decodedToken) {
 
+  var parsedUrl = url.parse(urlPath);
+  urlPath = parsedUrl.pathname;
   if (!decodedToken.api_product_list) { debug('no api product list'); return false; }
 
   return decodedToken.api_product_list.some(function (product) {
@@ -219,6 +221,7 @@ const checkIfAuthorized = module.exports.checkIfAuthorized = function checkIfAut
             debug('found matching proxy rule');
             return;
           }
+          
           const apiproxy = tempApiProxy.includes(proxy.base_path)
             ? tempApiProxy
             : proxy.base_path + (tempApiProxy.startsWith("/") ? "" : "/") +  tempApiProxy
@@ -228,7 +231,7 @@ const checkIfAuthorized = module.exports.checkIfAuthorized = function checkIfAut
 
           if(apiproxy.includes(SUPPORTED_DOUBLE_ASTERIK_PATTERN)){
             const regex = apiproxy.replace(/\*\*/gi,".*")
-            matchesProxyRules =  urlPath.match(regex)
+            matchesProxyRules = urlPath.match(regex)
           }else{
             if(apiproxy.includes(SUPPORTED_SINGLE_ASTERIK_PATTERN)){
               const regex = apiproxy.replace(/\*/gi,"[^/]+");
@@ -237,6 +240,7 @@ const checkIfAuthorized = module.exports.checkIfAuthorized = function checkIfAut
               // if(apiproxy.includes(SUPPORTED_SINGLE_FORWARD_SLASH_PATTERN)){
               // }
               matchesProxyRules = urlPath == apiproxy;
+
             }
           }
       })


### PR DESCRIPTION
This has been a minor ongoing issue for the oauth key verification code path. Case is as follows.

HTTP Request Made like so
```
HTTP/1.1 GET /edgemicro_proxy_basepath?foo=bar
x-api-key: VALIDKEYHERE
```
Would return a 403. This was an issue with path matching against products in edgemicro where a trailing slash was expected.

So users would need to make an HTTP Request like so to get a key verified.
```
HTTP/1.1 GET /edgemicro_proxy_basepath/?foo=bar
x-api-key: VALIDKEYHERE
```

This fix allows for the first case without the trailing slash to properly verify an API key.

@srinandan Thoughts on this fix? 
