### PR TITLE
Honor HTTP proxy config in quota plugin

### DIFF
--- a/quota/index.js
+++ b/quota/index.js
@@ -22,6 +22,7 @@ module.exports.init = function(config, logger, stats) {
       return;
     }     
 
+    config[productName].request = config.request;
     var quota = Quota.create(config[productName]);
     quotas[productName] = quota.connectMiddleware().apply(options);
     debug('created quota for', productName);


### PR DESCRIPTION
Since `volos-quota-apigee` is created from product-specific config, top-level `request` config key is left behind. This populates each product-specific config by copying the request key from the config object.