### PR TITLE
Adding the "invalid_auth" error message to the list of 401 inducing messages

### DIFF
--- a/oauth/index.js
+++ b/oauth/index.js
@@ -218,7 +218,7 @@ const checkIfAuthorized = module.exports.checkIfAuthorized = function checkIfAut
   //
   debug('product only: '+ productOnly);
   //
-  
+
   if (!decodedToken.api_product_list) { debug('no api product list'); return false; }
 
   return decodedToken.api_product_list.some(function (product) {
@@ -290,6 +290,7 @@ function sendError(req, res, next, logger, stats, code, message) {
     case 'invalid_token':
     case 'missing_authorization':
     case 'invalid_authorization':
+    case 'invalid_auth':
       res.statusCode = 401;
       break;
     case 'gateway_timeout':


### PR DESCRIPTION
This is a fix for [issue-61](https://github.com/apigee/microgateway-plugins/issues/61). When oauth configuration specifies that allowAPIKeyOnly is true, oauth plugin must reject a reject without x-api-key header using a 401 response code. Currently it returns a 500.
This fix is a simple addition of the invalid_auth error code to the list of messages that generates a 401 in sendError.