### PR TITLE
updated condition in authorize function so that apikeys are not cached by default

### DIFF
--- a/apikeys/index.js
+++ b/apikeys/index.js
@@ -49,7 +49,7 @@ module.exports.init = function(config, logger, stats) {
 				delete(req.headers[apiKeyHeaderName]); // don't pass this header to target
 			}
             exchangeApiKeyForToken(req, res, next, config, logger, stats, middleware, apiKey);
-        } else if (req.reqUrl && req.reqUrl.query && (apiKey = req.reqUrl.query[apiKeyHeaderName])) {	
+        } else if (req.reqUrl && req.reqUrl.query && (apiKey = req.reqUrl.query[apiKeyHeaderName])) {
             exchangeApiKeyForToken(req, res, next, config, logger, stats, middleware, apiKey);
         } else {
             if (config.allowNoAuthorization) {
@@ -63,7 +63,7 @@ module.exports.init = function(config, logger, stats) {
 
     var exchangeApiKeyForToken = function(req, res, next, config, logger, stats, middleware, apiKey) {
         var cacheControl = req.headers["cache-control"];
-        if (cacheKey || (!cacheControl || (cacheControl && cacheControl.indexOf("no-cache") < 0))) { // caching is allowed
+        if (cacheKey || (cacheControl && cacheControl.indexOf("no-cache") < 0)) { // caching is allowed
             cache.read(apiKey, function(err, value) {
                 if (value) {
                     if (Date.now() / 1000 < value.exp) { // not expired yet (token expiration is in seconds)
@@ -134,7 +134,7 @@ module.exports.init = function(config, logger, stats) {
 					return next();
 				} else {
 	                debug("verify apikey access_denied");
-	                return sendError(req, res, next, logger, stats, "access_denied", response.statusMessage);					
+	                return sendError(req, res, next, logger, stats, "access_denied", response.statusMessage);
 				}
             }
             verify(body, config, logger, stats, middleware, req, res, next, apiKey);
@@ -185,7 +185,7 @@ module.exports.init = function(config, logger, stats) {
 
             if (apiKey) {
                 var cacheControl = req.headers["cache-control"];
-                if (cacheKey || (!cacheControl || (cacheControl && cacheControl.indexOf("no-cache") < 0))) { // caching is toFixed
+                if (cacheKey || (cacheControl && cacheControl.indexOf("no-cache") < 0)) { // caching is toFixed
                     // default to now (in seconds) + 30m if not set
                     decodedToken.exp = decodedToken.exp || +(((Date.now() / 1000) + 1800).toFixed(0));
                     //apiKeyCache[apiKey] = decodedToken;


### PR DESCRIPTION
fixes #78 

I made the following changes to the plugin code:
1) If a developer includes the following stanza, then API keys will be cached even if the request includes a Cache-Control: no-cache header.
apikeys:
 cacheKey: true

2) The cacheKey variable is set to false by default, but the API Key was still cached.  I updated the condition so that API key caching is disabled by default.  Developers will need to enabled caching by setting `cacheKey: true` in the Edge Microgateway config file. 