### PR TITLE
updating test-helper to run successfully with Mocha and resolve sever…

### DIFF
--- a/test-helper/package.json
+++ b/test-helper/package.json
@@ -12,6 +12,7 @@
     "debug": "^2.2.0",
     "lodash": "^4.17.5",
     "mocha": "^2.2.4",
-    "supertest": "^1.1.0"
+    "supertest": "^1.1.0",
+    "node-cmd": "^3.0.0"
   }
 }


### PR DESCRIPTION
Test helper is used during some of the Mocha tests to test that the custom plugin will execute successfully within the Edge Microgateway.  

I attempted to execute the spikearrest plugin's Mocha test and received several errors from this test-helper.  I updated it so that the Mocha's test work correctly now.  Developers should be able to use this test-helper going forward to test custom plugins via a Mocha script now.  

The next action item is to create a README on how to use this test-helper. 