### PR TITLE
upgrade volos quota version used

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -478,7 +478,7 @@
     "dotenv": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.0.0.tgz",
-      "integrity": "sha1-7TEMFltOipe7dFsKnZnDG9pWZEA="
+      "integrity": "sha512-30xVGqjLjiUOArT4+M5q9sYdvuR4riM6yK9wMcas9Vbp6zZa+ocC9dp6QoftuhTPhFAiLK/0C5Ni2nou/Bk8lg=="
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -2490,9 +2490,9 @@
       }
     },
     "volos-quota-apigee": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/volos-quota-apigee/-/volos-quota-apigee-0.13.1.tgz",
-      "integrity": "sha1-e513DBR4TBrcxdyBOUSm7GokB/U=",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/volos-quota-apigee/-/volos-quota-apigee-0.13.2.tgz",
+      "integrity": "sha512-/CtkiAI4Uj0+oDkRbgRRbnkSjcJ3P2Wpqk/k+yIAVVCqwwKyY1SkHniN9n1r+4SQoV7XmpUcvhk/ZEfPamMOzQ==",
       "requires": {
         "apigee-access": ">=1.2.x",
         "debug": "^2.2.0",
@@ -2522,9 +2522,9 @@
       }
     },
     "volos-quota-common": {
-      "version": "0.11.6",
-      "resolved": "https://registry.npmjs.org/volos-quota-common/-/volos-quota-common-0.11.6.tgz",
-      "integrity": "sha512-I1GtOpTDLlpiDcsp6QdKTsN9wvxqd0/jZ1Mf03IByrBGAcLd3Xw//lfETRr0f/ktVjag6Lh0uDGen2wes34btA==",
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/volos-quota-common/-/volos-quota-common-0.11.7.tgz",
+      "integrity": "sha512-GTikXZAcd70vio+kyjBUfWOKc/7p8kyhbOyZvOGTMyKJrnJPkg5tJXs03daxfEZ4wG6dycsldNHdWURYrbLwAg==",
       "requires": {
         "debug": "^2.2.0",
         "underscore": "1.6.x"
@@ -2533,7 +2533,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
           }
@@ -2542,6 +2542,11 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "underscore": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "toobusy-js": "^0.5.1",
     "volos-analytics-apigee": "^0.4.0",
     "volos-cache-memory": "^0.10.0",
-    "volos-quota-apigee": "^0.13.0",
-    "volos-quota-common": "^0.11.6",
+    "volos-quota-apigee": "^0.13.2",
+    "volos-quota-common": "^0.11.7",
     "volos-quota-memory": "^0.11.0",
     "volos-spikearrest-memory": "^0.10.0",
     "xml2js": "^0.4.17"


### PR DESCRIPTION
Upgrades the Volos quota version being used that: 1. Fixes a bug in the quota buffer that caused flush to not happen on based on bufferSize. 2. Removes extra synchronization call to Apigee on bucket creation.