### PR TITLE
Fix resource path pattern matching

### DIFF
--- a/apikeys/index.js
+++ b/apikeys/index.js
@@ -258,23 +258,20 @@ const checkIfAuthorized = module.exports.checkIfAuthorized = function checkIfAut
                 if (apiproxy.endsWith("/") && !urlPath.endsWith("/")) {
                     urlPath = urlPath + "/";
                 }
-
+                let regex = apiproxy;
                 if (apiproxy.includes(SUPPORTED_DOUBLE_ASTERISK_PATTERN)) {
-                    const regex = apiproxy.replace(/\*\*/gi, ".*")
-                    matchesProxyRules = urlPath.match(regex)
+                    regex = regex.replace(/\*\*/gi, ".+");
+                }
+                if (apiproxy.includes(SUPPORTED_SINGLE_ASTERISK_PATTERN)) {
+                    regex = regex.replace(/\*/gi, "[^/]+");
+                }
+                if (regex !== apiproxy) {
+                    regex = "^" + regex + "$";
+                    matchesProxyRules = urlPath.match(regex) !== null;
                 } else {
-                    if (apiproxy.includes(SUPPORTED_SINGLE_ASTERISK_PATTERN)) {
-                        const regex = apiproxy.replace(/\*/gi, "[^/]+");
-                        matchesProxyRules = urlPath.match(regex)
-                    } else {
-                        // if(apiproxy.includes(SUPPORTED_SINGLE_FORWARD_SLASH_PATTERN)){
-                        // }
-                        matchesProxyRules = urlPath === apiproxy;
-
-                    }
+                    matchesProxyRules = urlPath === apiproxy;
                 }
             })
-
         } else {
             matchesProxyRules = true
         }

--- a/apikeys/index.js
+++ b/apikeys/index.js
@@ -12,8 +12,8 @@ var requestLib = require("request");
 var _ = require("lodash");
 
 const PRIVATE_JWT_VALUES = ["application_name", "client_id", "api_product_list", "iat", "exp"];
-const SUPPORTED_DOUBLE_ASTERIK_PATTERN = "**";
-const SUPPORTED_SINGLE_ASTERIK_PATTERN = "*";
+const SUPPORTED_DOUBLE_ASTERISK_PATTERN = "**";
+const SUPPORTED_SINGLE_ASTERISK_PATTERN = "*";
 // const SUPPORTED_SINGLE_FORWARD_SLASH_PATTERN = "/";    // ?? this has yet to be used in any module.
 
 const acceptAlg = ["RS256"];
@@ -259,11 +259,11 @@ const checkIfAuthorized = module.exports.checkIfAuthorized = function checkIfAut
                     urlPath = urlPath + "/";
                 }
 
-                if (apiproxy.includes(SUPPORTED_DOUBLE_ASTERIK_PATTERN)) {
+                if (apiproxy.includes(SUPPORTED_DOUBLE_ASTERISK_PATTERN)) {
                     const regex = apiproxy.replace(/\*\*/gi, ".*")
                     matchesProxyRules = urlPath.match(regex)
                 } else {
-                    if (apiproxy.includes(SUPPORTED_SINGLE_ASTERIK_PATTERN)) {
+                    if (apiproxy.includes(SUPPORTED_SINGLE_ASTERISK_PATTERN)) {
                         const regex = apiproxy.replace(/\*/gi, "[^/]+");
                         matchesProxyRules = urlPath.match(regex)
                     } else {

--- a/lib/basicAuth.js
+++ b/lib/basicAuth.js
@@ -25,8 +25,8 @@ map.setup({
 //
 const acceptAlg = ['RS256'];
 
-const SUPPORTED_DOUBLE_ASTERIK_PATTERN = "**";
-const SUPPORTED_SINGLE_ASTERIK_PATTERN = "*";
+const SUPPORTED_DOUBLE_ASTERISK_PATTERN = "**";
+const SUPPORTED_SINGLE_ASTERISK_PATTERN = "*";
 //const SUPPORTED_SINGLE_FORWARD_SLASH_PATTERN = "/";
 
 const AUTH_HEADER_REGEX = /Bearer (.+)/;
@@ -412,11 +412,11 @@ class BasicAuthorizerPlugin {
                         urlPath = urlPath + "/";
                     }
 
-                    if ( apiproxy.includes(SUPPORTED_DOUBLE_ASTERIK_PATTERN) ) {
+                    if ( apiproxy.includes(SUPPORTED_DOUBLE_ASTERISK_PATTERN) ) {
                         const regex = apiproxy.replace(/\*\*/gi, ".*")
                         return(urlPath.match(regex) !== null )
                     } else {
-                        if ( apiproxy.includes(SUPPORTED_SINGLE_ASTERIK_PATTERN) ) {
+                        if ( apiproxy.includes(SUPPORTED_SINGLE_ASTERISK_PATTERN) ) {
                             const regex = apiproxy.replace(/\*/gi, "[^/]+");
                             return(urlPath.match(regex) !== null )
                         } else {

--- a/oauth/index.js
+++ b/oauth/index.js
@@ -14,8 +14,8 @@ var _ = require('lodash');
 
 const authHeaderRegex = /Bearer (.+)/;
 const PRIVATE_JWT_VALUES = ['application_name', 'client_id', 'api_product_list', 'iat', 'exp'];
-const SUPPORTED_DOUBLE_ASTERIK_PATTERN = "**";
-const SUPPORTED_SINGLE_ASTERIK_PATTERN = "*";
+const SUPPORTED_DOUBLE_ASTERISK_PATTERN = "**";
+const SUPPORTED_SINGLE_ASTERISK_PATTERN = "*";
 // const SUPPORTED_SINGLE_FORWARD_SLASH_PATTERN = "/";
 
 const acceptAlg = ['RS256'];
@@ -384,23 +384,20 @@ const checkIfAuthorized = module.exports.checkIfAuthorized = function checkIfAut
                 if (apiproxy.endsWith("/") && !urlPath.endsWith("/")) {
                     urlPath = urlPath + "/";
                 }
-
-                if (apiproxy.includes(SUPPORTED_DOUBLE_ASTERIK_PATTERN)) {
-                    const regex = apiproxy.replace(/\*\*/gi, ".*")
-                    matchesProxyRules = urlPath.match(regex)
+                let regex = apiproxy;
+                if (apiproxy.includes(SUPPORTED_DOUBLE_ASTERISK_PATTERN)) {
+                    regex = regex.replace(/\*\*/gi, ".+");
+                }
+                if (apiproxy.includes(SUPPORTED_SINGLE_ASTERISK_PATTERN)) {
+                    regex = regex.replace(/\*/gi, "[^/]+");
+                }
+                if (regex !== apiproxy) {
+                    regex = "^" + regex + "$";
+                    matchesProxyRules = urlPath.match(regex) !== null;
                 } else {
-                    if (apiproxy.includes(SUPPORTED_SINGLE_ASTERIK_PATTERN)) {
-                        const regex = apiproxy.replace(/\*/gi, "[^/]+");
-                        matchesProxyRules = urlPath.match(regex)
-                    } else {
-                        // if(apiproxy.includes(SUPPORTED_SINGLE_FORWARD_SLASH_PATTERN)){
-                        // }
-                        matchesProxyRules = urlPath === apiproxy;
-
-                    }
+                    matchesProxyRules = urlPath === apiproxy;
                 }
             })
-
         } else {
             matchesProxyRules = true
         }

--- a/oauthv2/index.js
+++ b/oauthv2/index.js
@@ -11,8 +11,8 @@ var _ = require('lodash');
 
 const authHeaderRegex = /Bearer (.+)/;
 const PRIVATE_JWT_VALUES = ['application_name', 'client_id', 'api_product_list', 'iat', 'exp'];
-const SUPPORTED_DOUBLE_ASTERIK_PATTERN = "**";
-const SUPPORTED_SINGLE_ASTERIK_PATTERN = "*";
+const SUPPORTED_DOUBLE_ASTERISK_PATTERN = "**";
+const SUPPORTED_SINGLE_ASTERISK_PATTERN = "*";
 //const SUPPORTED_SINGLE_FORWARD_SLASH_PATTERN = "/";
 
 const acceptAlg = ['RS256'];
@@ -250,11 +250,11 @@ const checkIfAuthorized = module.exports.checkIfAuthorized = function checkIfAut
                     urlPath = urlPath + "/";
                 }
 
-                if (apiproxy.includes(SUPPORTED_DOUBLE_ASTERIK_PATTERN)) {
+                if (apiproxy.includes(SUPPORTED_DOUBLE_ASTERISK_PATTERN)) {
                     const regex = apiproxy.replace(/\*\*/gi, ".*")
                     matchesProxyRules = urlPath.match(regex)
                 } else {
-                    if (apiproxy.includes(SUPPORTED_SINGLE_ASTERIK_PATTERN)) {
+                    if (apiproxy.includes(SUPPORTED_SINGLE_ASTERISK_PATTERN)) {
                         const regex = apiproxy.replace(/\*/gi, "[^/]+");
                         matchesProxyRules = urlPath.match(regex)
                     } else {

--- a/oauthv2/index.js
+++ b/oauthv2/index.js
@@ -249,23 +249,20 @@ const checkIfAuthorized = module.exports.checkIfAuthorized = function checkIfAut
                 if (apiproxy.endsWith("/") && !urlPath.endsWith("/")) {
                     urlPath = urlPath + "/";
                 }
-
+                let regex = apiproxy;
                 if (apiproxy.includes(SUPPORTED_DOUBLE_ASTERISK_PATTERN)) {
-                    const regex = apiproxy.replace(/\*\*/gi, ".*")
-                    matchesProxyRules = urlPath.match(regex)
+                    regex = regex.replace(/\*\*/gi, ".+");
+                }
+                if (apiproxy.includes(SUPPORTED_SINGLE_ASTERISK_PATTERN)) {
+                    regex = regex.replace(/\*/gi, "[^/]+");
+                }
+                if (regex !== apiproxy) {
+                    regex = "^" + regex + "$";
+                    matchesProxyRules = urlPath.match(regex) !== null;
                 } else {
-                    if (apiproxy.includes(SUPPORTED_SINGLE_ASTERISK_PATTERN)) {
-                        const regex = apiproxy.replace(/\*/gi, "[^/]+");
-                        matchesProxyRules = urlPath.match(regex)
-                    } else {
-                        // if(apiproxy.includes(SUPPORTED_SINGLE_FORWARD_SLASH_PATTERN)){
-                        // }
-                        matchesProxyRules = urlPath === apiproxy;
-
-                    }
+                    matchesProxyRules = urlPath === apiproxy;
                 }
             })
-
         } else {
             matchesProxyRules = true
         }


### PR DESCRIPTION
This pull request fixes several things related to resource path matching in the oauth-category plugins.

It fixes a critical security issue: The resource path patterns defined in products are not matched against the entire request path but only require a subpath match (missing `^` and `$`).

Further, it brings the microgateway resource path processing more in line with the documentation at [Manage API products](https://docs.apigee.com/api-platform/publish/create-api-products#behavior-resource-path) by:
* Allowing the use of single AND double asterisk in one URL
* Disallowing empty strings with `/**`

It also makes sure `matchesProxyRules` remains a boolean instead of the array returned by `String.prototype.match()`.