### PR TITLE
140075602 return correct response if not 200

### DIFF
--- a/oauth/index.js
+++ b/oauth/index.js
@@ -35,9 +35,13 @@ map.setup({
 
 var tokenCacheSize = 100;
 
+let oauthConfigObj = null;
+
 module.exports.init = function(config, logger, stats) {
 
     if ( config === undefined || !config ) return(undefined);
+
+    oauthConfigObj = config;
 
     var request = config.request ? requestLib.defaults(config.request) : requestLib;
     var keys = config.jwk_keys ? JSON.parse(config.jwk_keys) : null;
@@ -197,8 +201,8 @@ module.exports.init = function(config, logger, stats) {
                 return sendError(req, res, next, logger, stats, 'gateway_timeout', err.message);
             }
             if (response.statusCode !== 200) {
-                debug('verify apikey access_denied');
-                return sendError(req, res, next, logger, stats, 'access_denied', response.statusMessage);
+                debug('verify apikey failure',response.statusCode, response.statusMessage, body);
+                return sendError(req, res, next, logger, stats, 'access_denied', response.statusMessage,response);
             }
             verify(body, config, logger, stats, middleware, req, res, next, apiKey);
         });
@@ -462,9 +466,15 @@ function setResponseCode(res,code) {
     }
 }
 
-function sendError(req, res, next, logger, stats, code, message) {
+function sendError(req, res, next, logger, stats, code, message, upstreamResp) {
 
-    setResponseCode(res,code);
+    if ( upstreamResp && oauthConfigObj.hasOwnProperty('useUpstreamResponse') && oauthConfigObj.useUpstreamResponse === true ) {
+        res.statusCode = upstreamResp.statusCode;
+        res.statusMessage = upstreamResp.statusMessage;
+        code = 'upstream_error';
+    } else {
+        setResponseCode(res,code);
+    }
 
     var response = {
         error: code,


### PR DESCRIPTION
Return upstream statusCode, statusMessage and error='upstream_error' in case of edgemicro-auth proxy response not 200.

To use upstream response set useUpstreamResponse: true in yaml config for oauth plugin, Eg is:

oauth:
  ...
  useUpstreamResponse: true