### PR TITLE
PR for bug b142677575

### DIFF
--- a/apikeys/index.js
+++ b/apikeys/index.js
@@ -12,8 +12,8 @@ var requestLib = require("request");
 var _ = require("lodash");
 
 const PRIVATE_JWT_VALUES = ["application_name", "client_id", "api_product_list", "iat", "exp"];
-const SUPPORTED_DOUBLE_ASTERIK_PATTERN = "**";
-const SUPPORTED_SINGLE_ASTERIK_PATTERN = "*";
+const SUPPORTED_DOUBLE_ASTERISK_PATTERN = "**";
+const SUPPORTED_SINGLE_ASTERISK_PATTERN = "*";
 // const SUPPORTED_SINGLE_FORWARD_SLASH_PATTERN = "/";    // ?? this has yet to be used in any module.
 
 const acceptAlg = ["RS256"];
@@ -287,11 +287,11 @@ const checkIfAuthorized = module.exports.checkIfAuthorized = function checkIfAut
                     urlPath = urlPath + "/";
                 }
 
-                if (apiproxy.includes(SUPPORTED_DOUBLE_ASTERIK_PATTERN)) {
+                if (apiproxy.includes(SUPPORTED_DOUBLE_ASTERISK_PATTERN)) {
                     const regex = apiproxy.replace(/\*\*/gi, ".*")
                     matchesProxyRules = urlPath.match(regex)
                 } else {
-                    if (apiproxy.includes(SUPPORTED_SINGLE_ASTERIK_PATTERN)) {
+                    if (apiproxy.includes(SUPPORTED_SINGLE_ASTERISK_PATTERN)) {
                         const regex = apiproxy.replace(/\*/gi, "[^/]+");
                         matchesProxyRules = urlPath.match(regex)
                     } else {

--- a/lib/basicAuth.js
+++ b/lib/basicAuth.js
@@ -25,8 +25,8 @@ const CONSOLE_LOG_TAG_COMP = 'microgateway-plugins basicAuth';
 //
 const acceptAlg = ['RS256'];
 
-const SUPPORTED_DOUBLE_ASTERIK_PATTERN = "**";
-const SUPPORTED_SINGLE_ASTERIK_PATTERN = "*";
+const SUPPORTED_DOUBLE_ASTERISK_PATTERN = "**";
+const SUPPORTED_SINGLE_ASTERISK_PATTERN = "*";
 //const SUPPORTED_SINGLE_FORWARD_SLASH_PATTERN = "/";
 
 const AUTH_HEADER_REGEX = /Bearer (.+)/;
@@ -412,11 +412,11 @@ class BasicAuthorizerPlugin {
                         urlPath = urlPath + "/";
                     }
 
-                    if ( apiproxy.includes(SUPPORTED_DOUBLE_ASTERIK_PATTERN) ) {
+                    if ( apiproxy.includes(SUPPORTED_DOUBLE_ASTERISK_PATTERN) ) {
                         const regex = apiproxy.replace(/\*\*/gi, ".*")
                         return(urlPath.match(regex) !== null )
                     } else {
-                        if ( apiproxy.includes(SUPPORTED_SINGLE_ASTERIK_PATTERN) ) {
+                        if ( apiproxy.includes(SUPPORTED_SINGLE_ASTERISK_PATTERN) ) {
                             const regex = apiproxy.replace(/\*/gi, "[^/]+");
                             return(urlPath.match(regex) !== null )
                         } else {

--- a/oauth/index.js
+++ b/oauth/index.js
@@ -20,7 +20,6 @@ var _ = require('lodash');
 
 const authHeaderRegex = /Bearer (.+)/;
 const PRIVATE_JWT_VALUES = ['application_name', 'client_id', 'api_product_list', 'iat', 'exp'];
-const SUPPORTED_TOKEN_ASTERISK_PATTERN = "/*/2/**";
 const SUPPORTED_DOUBLE_ASTERISK_PATTERN = "**";
 const SUPPORTED_SINGLE_ASTERISK_PATTERN = "*";
 // const SUPPORTED_SINGLE_FORWARD_SLASH_PATTERN = "/";
@@ -429,14 +428,11 @@ const checkIfAuthorized = module.exports.checkIfAuthorized = function checkIfAut
                 if (apiproxy.endsWith("/") && !urlPath.endsWith("/")) {
                     urlPath = urlPath + "/";
                 }
-                if (apiproxy.includes(SUPPORTED_DOUBLE_ASTERISK_PATTERN) && ! apiproxy.includes(SUPPORTED_TOKEN_ASTERISK_PATTERN)  ) {
+                if (apiproxy.includes(SUPPORTED_DOUBLE_ASTERISK_PATTERN) ) {
                     const proxyRegEx = new RegExp(`^${proxy.base_path.replace(/\//g,'\\/')}\/\\w+(\\/?).*$`, 'ig');
                     matchesProxyRules = urlPath.match(proxyRegEx)
                 } else {
-                    if (apiproxy.includes(SUPPORTED_TOKEN_ASTERISK_PATTERN)) { 
-                        const proxyRegEx = new RegExp(`^${proxy.base_path.replace(/\//g,'\\/')}\/\\w+(\\/?)2\/.*$`, 'ig');
-                        matchesProxyRules = urlPath.match(proxyRegEx)
-                    } else if (apiproxy.includes(SUPPORTED_SINGLE_ASTERISK_PATTERN)) {
+                    if (apiproxy.includes(SUPPORTED_SINGLE_ASTERISK_PATTERN)) {
                         const proxyRegEx = new RegExp(`^${proxy.base_path.replace(/\//g,'\\/')}\/\\w+(\\/?)$`, 'ig');
                         matchesProxyRules = urlPath.match(proxyRegEx)
                     } else {

--- a/oauth/index.js
+++ b/oauth/index.js
@@ -20,8 +20,9 @@ var _ = require('lodash');
 
 const authHeaderRegex = /Bearer (.+)/;
 const PRIVATE_JWT_VALUES = ['application_name', 'client_id', 'api_product_list', 'iat', 'exp'];
-const SUPPORTED_DOUBLE_ASTERIK_PATTERN = "**";
-const SUPPORTED_SINGLE_ASTERIK_PATTERN = "*";
+const SUPPORTED_TOKEN_ASTERISK_PATTERN = "/*/2/**";
+const SUPPORTED_DOUBLE_ASTERISK_PATTERN = "**";
+const SUPPORTED_SINGLE_ASTERISK_PATTERN = "*";
 // const SUPPORTED_SINGLE_FORWARD_SLASH_PATTERN = "/";
 
 const LOG_TAG_COMP = 'oauth';
@@ -389,22 +390,12 @@ module.exports.init = function(config, logger, stats) {
     };
 
 }  // end of init
-
-
-
-
-
-
-
 // from the product name(s) on the token, find the corresponding proxy
 // then check if that proxy is one of the authorized proxies in bootstrap
 const checkIfAuthorized = module.exports.checkIfAuthorized = function checkIfAuthorized(config, urlPath, proxy, decodedToken) {
 
     var parsedUrl = url.parse(urlPath);
-    //
     debug('product only: ' + productOnly);
-    //
-
     if (!decodedToken.api_product_list) {
         debug('no api product list');
         return false;
@@ -421,7 +412,6 @@ const checkIfAuthorized = module.exports.checkIfAuthorized = function checkIfAut
             }
         }
 
-
         const apiproxies = config.product_to_api_resource[product];
 
         var matchesProxyRules = false;
@@ -432,7 +422,6 @@ const checkIfAuthorized = module.exports.checkIfAuthorized = function checkIfAut
                     debug('found matching proxy rule');
                     return;
                 }
-
                 urlPath = parsedUrl.pathname;
                 const apiproxy = tempApiProxy.includes(proxy.base_path) ?
                     tempApiProxy :
@@ -440,19 +429,20 @@ const checkIfAuthorized = module.exports.checkIfAuthorized = function checkIfAut
                 if (apiproxy.endsWith("/") && !urlPath.endsWith("/")) {
                     urlPath = urlPath + "/";
                 }
-
-                if (apiproxy.includes(SUPPORTED_DOUBLE_ASTERIK_PATTERN)) {
-                    const regex = apiproxy.replace(/\*\*/gi, ".*")
-                    matchesProxyRules = urlPath.match(regex)
+                if (apiproxy.includes(SUPPORTED_DOUBLE_ASTERISK_PATTERN) && ! apiproxy.includes(SUPPORTED_TOKEN_ASTERISK_PATTERN)  ) {
+                    const proxyRegEx = new RegExp(`^${proxy.base_path.replace(/\//g,'\\/')}\/\\w+(\\/?).*$`, 'ig');
+                    matchesProxyRules = urlPath.match(proxyRegEx)
                 } else {
-                    if (apiproxy.includes(SUPPORTED_SINGLE_ASTERIK_PATTERN)) {
-                        const regex = apiproxy.replace(/\*/gi, "[^/]+");
-                        matchesProxyRules = urlPath.match(regex)
+                    if (apiproxy.includes(SUPPORTED_TOKEN_ASTERISK_PATTERN)) { 
+                        const proxyRegEx = new RegExp(`^${proxy.base_path.replace(/\//g,'\\/')}\/\\w+(\\/?)2\/.*$`, 'ig');
+                        matchesProxyRules = urlPath.match(proxyRegEx)
+                    } else if (apiproxy.includes(SUPPORTED_SINGLE_ASTERISK_PATTERN)) {
+                        const proxyRegEx = new RegExp(`^${proxy.base_path.replace(/\//g,'\\/')}\/\\w+(\\/?)$`, 'ig');
+                        matchesProxyRules = urlPath.match(proxyRegEx)
                     } else {
-                        // if(apiproxy.includes(SUPPORTED_SINGLE_FORWARD_SLASH_PATTERN)){
-                        // }
-                        matchesProxyRules = urlPath === apiproxy;
-
+                        // implies case: SUPPORTED_SINGLE_FORWARD_SLASH_PATTERN
+                        const proxyRegEx = new RegExp(`^${proxy.base_path.replace(/\//g,'\\/')}\/\\w+|\\W+$`, 'ig');
+                        matchesProxyRules = urlPath.match(proxyRegEx);
                     }
                 }
             })

--- a/oauthv2/index.js
+++ b/oauthv2/index.js
@@ -11,8 +11,8 @@ var _ = require('lodash');
 
 const authHeaderRegex = /Bearer (.+)/;
 const PRIVATE_JWT_VALUES = ['application_name', 'client_id', 'api_product_list', 'iat', 'exp'];
-const SUPPORTED_DOUBLE_ASTERIK_PATTERN = "**";
-const SUPPORTED_SINGLE_ASTERIK_PATTERN = "*";
+const SUPPORTED_DOUBLE_ASTERISK_PATTERN = "**";
+const SUPPORTED_SINGLE_ASTERISK_PATTERN = "*";
 //const SUPPORTED_SINGLE_FORWARD_SLASH_PATTERN = "/";
 
 const LOG_TAG_COMP = 'oauthv2';
@@ -250,11 +250,11 @@ const checkIfAuthorized = module.exports.checkIfAuthorized = function checkIfAut
                     urlPath = urlPath + "/";
                 }
 
-                if (apiproxy.includes(SUPPORTED_DOUBLE_ASTERIK_PATTERN)) {
+                if (apiproxy.includes(SUPPORTED_DOUBLE_ASTERISK_PATTERN)) {
                     const regex = apiproxy.replace(/\*\*/gi, ".*")
                     matchesProxyRules = urlPath.match(regex)
                 } else {
-                    if (apiproxy.includes(SUPPORTED_SINGLE_ASTERIK_PATTERN)) {
+                    if (apiproxy.includes(SUPPORTED_SINGLE_ASTERISK_PATTERN)) {
                         const regex = apiproxy.replace(/\*/gi, "[^/]+");
                         matchesProxyRules = urlPath.match(regex)
                     } else {

--- a/test/oauth-test.js
+++ b/test/oauth-test.js
@@ -25,7 +25,6 @@ var [slash, slashstar, slashstarstar, slashstarstar2 ] = [...testConfig()];
       slash.product_to_api_resource[apiName] = ["/"];
       slashstar.product_to_api_resource[apiName] = ["/*"];
       slashstarstar.product_to_api_resource[apiName] = ["/**"];
-      slashstarstar2.product_to_api_resource[apiName] = ["/*/2/**"];
 
 var oauthConfiigDefaults = {
   "authorization-header" : "authorization",
@@ -264,28 +263,6 @@ describe('oauth plugin', function() {
 
   })
 
-   // check for /*/2/** resource path.
-
-  it('checkIfAuthorized for  /*/2/**  ', function (done) {
-    var contains;
-    contains = oauth.checkIfAuthorized(slashstarstar2, `${proxy.base_path}`, proxy, token);  
-    assert(!contains)
-    contains = oauth.checkIfAuthorized(slashstarstar2, `${proxy.base_path}/`, proxy, token);
-    assert(!contains)
-    contains = oauth.checkIfAuthorized(slashstarstar2, `${proxy.base_path}/1`, proxy, token);
-    assert(!contains)
-    contains = oauth.checkIfAuthorized(slashstarstar2, `${proxy.base_path}/1/`, proxy, token);
-    assert(!contains)
-    contains = oauth.checkIfAuthorized(slashstarstar2, `${proxy.base_path}/1/2`, proxy, token);
-    assert(!contains)
-    contains = oauth.checkIfAuthorized(slashstarstar2, `${proxy.base_path}/1/2/`, proxy, token);
-    assert(contains)
-    contains = oauth.checkIfAuthorized(slashstarstar2, `${proxy.base_path}/1/2/3/`, proxy, token);
-    assert(contains)
-    contains = oauth.checkIfAuthorized(slashstarstar2, `${proxy.base_path}/1/a/2/3/`, proxy, token);
-    assert(!contains)
-    done()
-  })
 
   // should be identical for these tests
   var modules = { oauth, oauthv2 }


### PR DESCRIPTION
Changed resource pattern spelling mistake 'asterik' thanks to Philipp Schleier; changed regexs to match all four patterns /, /*, /**, /*/2/**. Added test coverage. Need to make /*/2/** dynamic parse token since practical use cases won't use '2' or a fixed position in slashes. Also need to update documentation on EMG to note that edgemicro_auth needs to be a standalone product added to the app configuration via management console not in a proxy product config.