### PR TITLE
Update oauth plugin to skip urls specified in config.yaml

### DIFF
--- a/oauth/README.md
+++ b/oauth/README.md
@@ -104,6 +104,12 @@ oauth:
   # Default: 100
 
   tokenCacheSize: 150
+  
+  # Skips the oauth if this section is present and any URIs mentioned. Example as:
+  
+  skipURI:
+     - /healthcheck
+     - /ping
 ```
 
 ## Enable the plugin

--- a/oauth/index.js
+++ b/oauth/index.js
@@ -73,6 +73,8 @@ module.exports.init = function(config, logger, stats) {
         var apiKey;
         //this flag will enable check against resource paths only
         productOnly = config.hasOwnProperty('productOnly') ? config.productOnly : false;
+        //this flag will check whether to skip oauth for mentioned urls 
+        var skipURIList = config.hasOwnProperty('skipURI') ? config.skipURI : null;	    
         //if local proxy is set, ignore proxies
         if (process.env.EDGEMICRO_LOCAL_PROXY === "1") {
             productOnly = true;
@@ -85,6 +87,19 @@ module.exports.init = function(config, logger, stats) {
         failopenGraceInterval = config.hasOwnProperty('failopenGraceInterval') ? config.failopenGraceInterval : 0;
         isFailOpen = config.hasOwnProperty('failOpen') ? config.failOpen : false;
         //
+        
+	//First check whether any urls are there to skip oauth or not
+	var pathIn = req.targetPath
+	if (skipURIList !== null) {
+	    for (var i=0; i < skipURIList.length; i++) {
+		//no wildcard
+		if (pathIn.startsWith(skipURIList[i])) {
+		    debug ('oauth skipped for ' + pathIn)
+		    return next();
+		}			
+	    }			
+	}
+        
         //support for enabling oauth or api key only
         var header = false;
         if (oauth_only) {

--- a/oauthv2/README.md
+++ b/oauthv2/README.md
@@ -62,6 +62,12 @@ oauth:
   # Default: 100
 
   tokenCacheSize: 150
+  
+  # Skips the oauth if this is present and urls are mentioned. Example as:
+  
+  skipURI:
+     - /healthcheck
+     - /ping  
 ```
 
 ## Enable the plugin

--- a/oauthv2/index.js
+++ b/oauthv2/index.js
@@ -44,6 +44,8 @@ module.exports.init = function(config, logger, stats) {
         acceptField.gracePeriod = gracePeriod;
         //this flag will enable check against resource paths only
         productOnly = config.hasOwnProperty('productOnly') ? config.productOnly : false;
+        //this flag will check whether to skip oauth for mentioned urls 
+        var skipURIList = config.hasOwnProperty('skipURI') ? config.skipURI : null;			
         //if local proxy is set, ignore proxies
         if (process.env.EDGEMICRO_LOCAL_PROXY === "1") {
             productOnly = true;
@@ -53,6 +55,19 @@ module.exports.init = function(config, logger, stats) {
         //max number of tokens in the cache
         tokenCacheSize = config.hasOwnProperty('tokenCacheSize') ? config.tokenCacheSize : 100;
         //
+	    
+	//First check whether any urls are there to skip oauth or not
+	var pathIn = req.targetPath
+	if (skipURIList !== null) {
+	    for (var i=0; i < skipURIList.length; i++) {
+		//no wildcard
+		if (pathIn.startsWith(skipURIList[i])) {
+		    debug ('oauth skipped for ' + pathIn)
+		    return next();
+		}			
+	    }			
+	}
+	    
         var header = false;
         if (!req.headers[authHeaderName]) {
             if (config.allowNoAuthorization) {


### PR DESCRIPTION
Fixes issue # 97

In config yaml, you can specify as follows under oauth for pings and healthchecks. Then the oauth plugin skips the oauth check if incoming path starts with the one that is mentioned in the yaml

```
oauth:
  allowNoAuthorization: false
  allowInvalidAuthorization: false
  skipURI:
      - /ping
      - /healthcheck
      - /api/ping
```



@srinandan @keyurkarnik @swilliams11 @indraneeldey 