### PR TITLE
Update extauth index.js to send x-client-id header

### DIFF
--- a/extauth/index.js
+++ b/extauth/index.js
@@ -124,7 +124,7 @@ module.exports.init = function(config, logger, stats) {
                                 if (!keepAuthHeader) {
                                     delete(req.headers['authorization']);
                                 }
-                                if (!sendErr) {
+                                if (sendErr) {
                                     //if this plugin is not sending errors, assume MG is not in local mode
                                     req.headers['x-api-key'] = jwtdecode.payloadObj[client_id];
                                 }
@@ -162,7 +162,7 @@ module.exports.init = function(config, logger, stats) {
                                     if (!keepAuthHeader) {
                                         delete(req.headers['authorization']);
                                     }
-                                    if (!sendErr) {
+                                    if (sendErr) {
                                         //if this plugin is not sending errors, assume MG is not in local mode
                                         req.headers['x-api-key'] = jwtdecode.payloadObj[client_id];
                                     }


### PR DESCRIPTION
@keyurkarnik @srinandan 

Looks like this plugin is not adding client_id to x-api-key header because of false check

In line 127 and 165,  checking for not sendErr. But sendErr is defaulted to true, which makes this check to False. But we need it as true Could you please fix this. as x-api-key is not being passed to oauth plugin and causing issues

**Actual :**
```
if (!sendErr) 
	//if this plugin is not sending errors, assume MG is not in local mode
	req.headers['x-api-key'] = jwtdecode.payloadObj[client_id];
}
```

**Expected:**
```
if (sendErr) 
	//if this plugin is not sending errors, assume MG is not in local mode
	req.headers['x-api-key'] = jwtdecode.payloadObj[client_id];
}
```