### PR TITLE
Cache the dynamic debug instances to avoid leaking them

### DIFF
--- a/lib/validateResourcePath.js
+++ b/lib/validateResourcePath.js
@@ -2,6 +2,7 @@
 
 var url = require('url');
 var debug_ = require('debug');
+const debugs = {};
 const DOUBLE_STAR_PLACEHOLDER = '@@@@';
 const SUPPORTED_SINGLE_FORWARD_SLASH_PATTERN = "/";
 
@@ -14,7 +15,13 @@ module.exports = function (config, req, res, decodedToken, productOnly, logger, 
     const proxy = res.proxy;
     let urlPath = req.reqUrl.path;
 
-    var debug = debug_('plugin:' + componentName);
+    // Cache the dynamic debug instances, to avoid a memory leak due to a bug currently present in the debug package.
+    // See https://github.com/visionmedia/debug/issues/678
+    var debug = debugs[componentName];
+    if (!debug) {
+        debug = debug_('plugin:' + componentName);
+        debugs[componentName] = debug;
+    }
 
     var parsedUrl = url.parse(urlPath);
     debug('product only: ' + productOnly);


### PR DESCRIPTION
This is due to visionmedia/debug#678.

Fixes #174