### PR TITLE
152640618 Correctly pass apikey to next plugin

### DIFF
--- a/extauth/index.js
+++ b/extauth/index.js
@@ -124,10 +124,7 @@ module.exports.init = function(config, logger, stats) {
                                 if (!keepAuthHeader) {
                                     delete(req.headers['authorization']);
                                 }
-                                if (!sendErr) {
-                                    //if this plugin is not sending errors, assume MG is not in local mode
-                                    req.headers['x-api-key'] = jwtdecode.payloadObj[client_id];
-                                }
+                                req.headers['x-api-key'] = jwtdecode.payloadObj[client_id];
                             } else {
                                 debug("ERROR - JWT is invalid");
                                 delete(req.headers['authorization']);
@@ -162,10 +159,7 @@ module.exports.init = function(config, logger, stats) {
                                     if (!keepAuthHeader) {
                                         delete(req.headers['authorization']);
                                     }
-                                    if (!sendErr) {
-                                        //if this plugin is not sending errors, assume MG is not in local mode
-                                        req.headers['x-api-key'] = jwtdecode.payloadObj[client_id];
-                                    }
+                                    req.headers['x-api-key'] = jwtdecode.payloadObj[client_id];
                                 } else {
                                     debug("ERROR - JWT is invalid");
                                     delete(req.headers['authorization']);


### PR DESCRIPTION
Remove the check of 'sendErr' when the token is valid because 'sendErr' should come in picture for failure cases
Set the header 'x-api-key' on req object and pass the control to next plugin